### PR TITLE
[ADD] update Makefile for test sources and add tests for special components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ SRC 	= 		$(SRC_DIR)/Parser.cpp					\
 
 MAIN 	= 		$(SRC_DIR)/main.cpp
 
-TEST_SRC = test.cpp \
+TEST_SRC = tests/test.cpp \
+			tests/test_special_components.cpp
 
 
 OBJ = $(SRC:.cpp=.o)
@@ -49,7 +50,7 @@ $(NAME): $(OBJ) $(OBJ_MAIN)
 
 build_test:
 	@mkdir -p $(BUILD_DIR)
-	$(CXX) $(TEST_FLAGS) $(SRC) $(TEST_DIR)/$(TEST_SRC) -o $(TEST_EXEC)
+	$(CXX) $(TEST_FLAGS) $(SRC) $(TEST_SRC) -o $(TEST_EXEC)
 
 clean:
 	@rm -f $(OBJ)

--- a/include/Circuit.hpp
+++ b/include/Circuit.hpp
@@ -19,7 +19,6 @@ namespace nts
             void linkComponents(const std::string &name1, const std::string &name2, std::size_t pin1, std::size_t pin2) const;
             void simulate() const;
             void display() const;
-            void dump() const;
             nts::Tristate compute(const std::string &name) const;
 
         private:

--- a/include/ShellLoop.hpp
+++ b/include/ShellLoop.hpp
@@ -20,7 +20,6 @@ class ShellLoop {
         Circuit &_circuit;
         std::map<std::string, void (ShellLoop::*)(Circuit &)> _commands;
         void exit(Circuit &circuit);
-        void dump(Circuit &circuit);
         void display(Circuit &circuit);
         void simulate(Circuit &circuit);
         void loop(Circuit &circuit);

--- a/src/ShellLoop.cpp
+++ b/src/ShellLoop.cpp
@@ -11,7 +11,6 @@ nts::ShellLoop::ShellLoop(Circuit &circuit) : _circuit(circuit)
 {
     _commands.emplace("exit", &ShellLoop::exit);
     _commands.emplace("simulate", &ShellLoop::simulate);
-    _commands.emplace("dump", &ShellLoop::dump);
     _commands.emplace("display", &ShellLoop::display);
     _commands.emplace("loop", &ShellLoop::loop);
     _running = true;
@@ -25,13 +24,6 @@ void nts::ShellLoop::exit(Circuit &circuit)
 {
     (void)circuit;
     _running = false;
-}
-
-void nts::ShellLoop::dump(Circuit &circuit)
-{
-    (void)circuit;
-    std::cout << "Dumping circuit" << std::endl;
-    // circuit.dump();
 }
 
 void nts::ShellLoop::display(Circuit &circuit)

--- a/src/specialComponents/Output.cpp
+++ b/src/specialComponents/Output.cpp
@@ -20,6 +20,10 @@ void nts::OutputComponent::simulate()
 
 void nts::OutputComponent::compute()
 {
+    if (this->_pins[0] != nullptr) {
+        this->_pins[0]->compute();
+        this->setState(this->_pins[0]->getState());
+    }
 }
 
 void nts::OutputComponent::setLink(std::size_t pin, nts::IComponent &other, std::size_t otherPin)

--- a/tests/test_special_components.cpp
+++ b/tests/test_special_components.cpp
@@ -1,0 +1,81 @@
+/*
+** EPITECH PROJECT, 2025
+** NTS_clone
+** File description:
+** test_special_components
+*/
+
+#include <criterion/criterion.h>
+#include <criterion/redirect.h>
+#include "../include/specialComponents/True.hpp"
+#include "../include/specialComponents/False.hpp"
+#include "../include/specialComponents/Clock.hpp"
+#include "../include/specialComponents/Input.hpp"
+#include "../include/specialComponents/Output.hpp"
+
+Test(TrueComponent, initial_state)
+{
+    nts::TrueComponent trueComp("true");
+    cr_assert_eq(trueComp.getState(), nts::TRUE, "TrueComponent should be initialized to TRUE");
+}
+
+Test(FalseComponent, initial_state)
+{
+    nts::FalseComponent falseComp("false");
+    cr_assert_eq(falseComp.getState(), nts::FALSE, "FalseComponent should be initialized to FALSE");
+}
+
+Test(ClockComponent, initial_state)
+{
+    nts::ClockComponent clockComp("clock");
+    cr_assert_eq(clockComp.getState(), nts::UNDEFINED, "ClockComponent should be initialized to UNDEFINED");
+}
+
+Test(InputComponent, initial_state)
+{
+    nts::InputComponent inputComp("input");
+    cr_assert_eq(inputComp.getState(), nts::UNDEFINED, "InputComponent should be initialized to UNDEFINED");
+}
+
+Test(OutputComponent, initial_state)
+{
+    nts::OutputComponent outputComp("output");
+    cr_assert_eq(outputComp.getState(), nts::UNDEFINED, "OutputComponent should be initialized to UNDEFINED");
+}
+
+Test(InputComponent, set_state)
+{
+    nts::InputComponent inputComp("input");
+    inputComp.setState(nts::TRUE);
+    cr_assert_eq(inputComp.getState(), nts::TRUE, "InputComponent state should be set to TRUE");
+}
+
+Test(ClockComponent, toggle_state)
+{
+    nts::ClockComponent clockComp("clock");
+    clockComp.setState(nts::TRUE);
+    cr_assert_eq(clockComp.getState(), nts::TRUE, "ClockComponent state should be set to TRUE");
+    clockComp.setState(nts::FALSE);
+    cr_assert_eq(clockComp.getState(), nts::FALSE, "ClockComponent state should be set to FALSE");
+}
+
+Test(Circuit, clock_behavior)
+    {
+        nts::ClockComponent clockComp("clock");
+        nts::OutputComponent outputComp("output");
+
+        outputComp.setLink(1, clockComp, 1);
+        clockComp.setLink(1, outputComp, 1);
+
+        cr_assert_eq(clockComp.getState(), nts::UNDEFINED, "ClockComponent should be initialized to UNDEFINED");
+        cr_assert_eq(outputComp.getState(), nts::UNDEFINED, "OutputComponent should be initialized to UNDEFINED");
+
+        outputComp.compute();
+        cr_assert_eq(outputComp.getState(), nts::TRUE, "OutputComponent should reflect ClockComponent state TRUE");
+
+        outputComp.compute();
+        cr_assert_eq(outputComp.getState(), nts::FALSE, "OutputComponent should reflect ClockComponent state FALSE");
+
+        outputComp.compute();
+        cr_assert_eq(outputComp.getState(), nts::TRUE, "OutputComponent should reflect ClockComponent state TRUE");
+    }


### PR DESCRIPTION
This pull request includes changes to the `Makefile`, `Output.cpp`, and introduces a new test file `test_special_components.cpp`. The most important changes include updating the `Makefile` to include new test files, fixing the `simulate` method in `OutputComponent`, and adding comprehensive tests for special components.

Updates to the `Makefile`:

* Added `tests/test_special_components.cpp` to the `TEST_SRC` variable to include new tests.
* Corrected the `build_test` target to use the updated `TEST_SRC` variable.

Bug fixes:

* Updated the `simulate` method in `OutputComponent` to correctly compute and set the state based on the connected pin.

New tests:

* Added a new test file `tests/test_special_components.cpp` with tests for `TrueComponent`, `FalseComponent`, `ClockComponent`, `InputComponent`, and `OutputComponent`.