### PR TITLE
Script bash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@
 B-OOP*
 nanotekspice
 *.json
+*.log

--- a/script.sh
+++ b/script.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Colors for output
+GREEN="\033[0;32m"
+RED="\033[0;31m"
+YELLOW="\033[0;33m"
+RESET="\033[0m"
+
+# Default directory
+TEST_DIR="./tests"
+
+# Check for command-line argument
+if [ $# -ge 1 ]; then
+    TEST_DIR="$1"
+fi
+
+# Display selected test directory
+echo -e "${YELLOW}Using test directory: ${TEST_DIR}${RESET}"
+
+# Check if nanotekspice executable exists
+if [ ! -f "./nanotekspice" ]; then
+    echo -e "${RED}Error: nanotekspice executable not found${RESET}"
+    echo "Make sure to compile the program first with 'make'"
+    exit 1
+fi
+
+# Find all .nts files in specified directory and subdirectories
+echo -e "${YELLOW}Searching for .nts circuit files...${RESET}"
+NTS_FILES=$(find "${TEST_DIR}" -type f -name "*.nts" 2>/dev/null)
+
+# Check if any .nts files were found
+if [ -z "$NTS_FILES" ]; then
+    echo -e "${YELLOW}No .nts files found in ${TEST_DIR}. Please check the directory path.${RESET}"
+    exit 0
+fi
+
+echo -e "Found $(echo "$NTS_FILES" | wc -l) circuit files to test."
+echo -e "${YELLOW}Starting component tests...${RESET}"
+echo "=========================================="
+
+PASS_COUNT=0
+FAIL_COUNT=0
+ERROR_LOG="component_test_errors.log"
+> "$ERROR_LOG" # Clear error log
+
+# Test each component file
+for file in $NTS_FILES; do
+    echo -n "Testing $(basename "$file")... "
+    
+    # Run nanotekspice with the file and exit immediately
+    # Using timeout to prevent hanging
+    output=$(timeout 2s ./nanotekspice "$file" <<< "exit" 2>&1)
+    exit_code=$?
+    
+    # Check exit status (0 = success, 124 = timeout, other = crash)
+    if [ $exit_code -eq 0 ]; then
+        echo -e "${GREEN}PASS${RESET}"
+        ((PASS_COUNT++))
+    elif [ $exit_code -eq 124 ]; then
+        echo -e "${RED}TIMEOUT${RESET}"
+        echo "File: $file - TIMEOUT" >> "$ERROR_LOG"
+        echo "Output: $output" >> "$ERROR_LOG"
+        ((FAIL_COUNT++))
+    else
+        echo -e "${RED}CRASH (exit code $exit_code)${RESET}"
+        echo "File: $file - EXIT CODE $exit_code" >> "$ERROR_LOG"
+        echo "Output: $output" >> "$ERROR_LOG"
+        ((FAIL_COUNT++))
+    fi
+done
+
+# Display summary
+echo "=========================================="
+echo -e "Test Summary:"
+echo -e "  ${GREEN}Passed: $PASS_COUNT${RESET}"
+echo -e "  ${RED}Failed: $FAIL_COUNT${RESET}"
+echo -e "  Total: $((PASS_COUNT + FAIL_COUNT))"
+
+if [ $FAIL_COUNT -eq 0 ]; then
+    echo -e "${GREEN}All components processed successfully!${RESET}"
+    exit 0
+else
+    echo -e "${RED}Some components caused crashes. See $ERROR_LOG for details.${RESET}"
+    exit 1
+fi

--- a/tests/Comp/bad.nts
+++ b/tests/Comp/bad.nts
@@ -1,0 +1,5 @@
+.chipsets:
+input   i
+output  o
+.links:
+a:1     o:1

--- a/tests/Comp/missing_links.nts
+++ b/tests/Comp/missing_links.nts
@@ -1,0 +1,3 @@
+.chipsets:
+input a
+output b

--- a/tests/Comp/nts_advanced/altered-counter.nts
+++ b/tests/Comp/nts_advanced/altered-counter.nts
@@ -1,0 +1,45 @@
+# Altered counter
+#
+#                             +-4040-+
+# in_reset ---1-+---\         |      |
+#               | or |-3---11->      >-9---5-+---\
+#           +-2-+---/         |      |       | or |-4- out_1
+#           |                 |      >-7---6-+---/
+#           |    cl_clock -10->      |
+#           |                 |      >-6---9-+---\
+#           |                 |      |       | or |-10- out_2
+#           |                 |      >-5---8-+---/
+#           |                 |      |
+#           |                 |      >-3-----+
+#           |                 |      |       |
+#           |                 |      >-2-    |
+#           |                 |      >-4-    |
+#           |                 |      >-13-   |
+#           |                 |      >-12-   |
+#           |                 |      >-14-   |
+#           |                 |      >-15-   |
+#           |                 |      >-1-    |
+#           |                 |      |       |
+#           |                 +------+       |
+#           |                                |
+#           +--------------------------------+
+
+.chipsets:
+clock cl_clock
+input in_reset
+4040 counter
+4071 or
+output out_1
+output out_2
+
+.links:
+counter:9 or:5
+counter:7 or:6
+counter:6 or:9
+counter:5 or:8
+counter:3 or:2
+counter:10 cl_clock:1
+counter:11 or:3
+in_reset:1 or:1
+out_1:1 or:4
+out_2:1 or:10

--- a/tests/Comp/nts_advanced/and-or-not.nts
+++ b/tests/Comp/nts_advanced/and-or-not.nts
@@ -1,0 +1,30 @@
+# Combinatory of OR, AND and NOT
+#
+# in_a -1-|1>o-2---1-|2>o-2---1-+---\
+#                               | or |-3-+
+# in_b -1-|3>o-2--------------2-+---/    +-1-|4>o-2---1-+---\
+#                                                       |and |-3- out
+# in_c -----------------------------------------------2-+---/
+
+.chipsets:
+input in_a
+input in_b
+input in_c
+output out
+not not1
+not not2
+not not3
+not not4
+or or
+and and
+
+.links:
+in_a:1 not1:1
+not1:2 not2:1
+not2:2 or:1
+in_b:1 not3:1
+not3:2 or:2
+or:3 not4:1
+not4:2 and:1
+in_c:1 and:2
+out:1 and:3

--- a/tests/Comp/nts_advanced/and.nts
+++ b/tests/Comp/nts_advanced/and.nts
@@ -1,0 +1,31 @@
+# Combinatory of AND (4081)
+#
+# in_a  -1-+---\
+#          |and |-3-+
+# in_b  -2-+---/    |
+#                   +-13-+---\
+# in_c  -5-+---\         |and |-11-+
+#          |and |-4---12-+---/     |
+# in_d  -6-+---/                   +-9-+---\
+#                                      |and |-10- out
+# in_e  -----------------------------8-+---/
+
+.chipsets:
+input in_a
+input in_b
+input in_c
+input in_d
+input in_e
+output out
+4081 and
+
+.links:
+in_a:1 and:1
+in_b:1 and:2
+and:3 and:13
+in_c:1 and:5
+in_d:1 and:6
+and:4 and:12
+and:11 and:9
+in_e:1 and:8
+and:10 out:1

--- a/tests/Comp/nts_single/2716_rom.nts
+++ b/tests/Comp/nts_single/2716_rom.nts
@@ -1,0 +1,70 @@
+# 2048 Bytes ROM (2716)
+#
+#             addr_05 -3-+
+#           addr_04 -4-+ | +-2- addr_06
+#         addr_03 -5-+ | | | +-1- addr_07
+#       addr_02 -6-+ | | | | | +-23- addr_08
+#     addr_01 -7-+ | | | | | | | +-22- addr_09
+#   addr_00 -8-+ | | | | | | | | | +-19- addr_10
+#              | | | | | | | | | | |
+#            +-v-v-v-v-v-v-v-v-v-v-v-+
+#            |                       |
+# enable -18->                  ign -<-12-
+#            |                       |
+#        -21->- ign             ign -<-19-
+#            |                       |
+#   read -20->                  ign -<-24-
+#            | 2716 ROM              |
+#            +----v-v-v-v-v-v-v-v----+
+#                 | | | | | | | |       
+#        out_0 -9-+ | | | | | | +-17- out_7
+#         out_1 -10-+ | | | | +-16- out_6
+#           out_2 -11-+ | | +-15- out_5
+#             out_3 -13-+ +-14- out_4
+
+.chipsets:
+input enable
+input read
+input addr_00
+input addr_01
+input addr_02
+input addr_03
+input addr_04
+input addr_05
+input addr_06
+input addr_07
+input addr_08
+input addr_09
+input addr_10
+output out_0
+output out_1
+output out_2
+output out_3
+output out_4
+output out_5
+output out_6
+output out_7
+2716 rom
+
+.links:
+enable:1 rom:18
+read:1 rom:20
+addr_00:1 rom:8
+addr_01:1 rom:7
+addr_02:1 rom:6
+addr_03:1 rom:5
+addr_04:1 rom:4
+addr_05:1 rom:3
+addr_06:1 rom:2
+addr_07:1 rom:1
+addr_08:1 rom:23
+addr_09:1 rom:22
+addr_10:1 rom:19
+out_0:1 rom:9
+out_1:1 rom:10
+out_2:1 rom:11
+out_3:1 rom:13
+out_4:1 rom:14
+out_5:1 rom:15
+out_6:1 rom:16
+out_7:1 rom:17

--- a/tests/Comp/nts_single/4001_nor.nts
+++ b/tests/Comp/nts_single/4001_nor.nts
@@ -1,0 +1,46 @@
+# NOR logic gates (4001)
+#
+#           +----------4001----------+
+# in_01  -1-|>-+---\         ignored-|-14-
+#           |  | or |o-+             |
+# in_02  -2-|>-+---/   |      /---+-<|-13- in_13
+#           |          |  +-o| or |  |
+# out_03 -3-|<---------+   |  \---+-<|-12- in_12
+#           |              |         |
+# out_04 -4-|<---------+  +--------->|-11- out_11
+#           |          |             |
+# in_05  -5-|>-+---\   |  +--------->|-10- out_10
+#           |  | or |o-+  |          |
+# in_06  -6-|>-+---/      |   /---+-<|-9-  in_09
+#           |             +-o| or |  |
+#        -7-|-ignored         \---+-<|-8-  in_08
+#           +------------------------+
+
+.chipsets:
+input in_01
+input in_02
+output out_03
+output out_04
+input in_05
+input in_06
+input in_08
+input in_09
+output out_10
+output out_11
+input in_12
+input in_13
+4001 gate
+
+.links:
+in_01:1 gate:1
+in_02:1 gate:2
+out_03:1 gate:3
+out_04:1 gate:4
+in_05:1 gate:5
+in_06:1 gate:6
+in_08:1 gate:8
+in_09:1 gate:9
+out_10:1 gate:10
+out_11:1 gate:11
+in_12:1 gate:12
+in_13:1 gate:13

--- a/tests/Comp/nts_single/4008_adder.nts
+++ b/tests/Comp/nts_single/4008_adder.nts
@@ -1,0 +1,60 @@
+# 4-bits Adder (4008)
+#
+#                  +-14- out_c
+#                  |
+#           +-4008-^------+
+#           |      |      |
+# in_b4 -15->---+--^--+   |
+#           |   | sum |--->-13- out_3
+# in_a4  -1->---+--+--+   |
+#           |      |      |
+# in_b3  -2->---+--^--+   |
+#           |   | sum |--->-12- out_2
+# in_a3  -3->---+--+--+   |
+#           |      |      |
+# in_b2  -4->---+--^--+   |
+#           |   | sum |--->-11- out_1
+# in_a2  -5->---+--+--+   |
+#           |      |      |
+# in_b1  -6->---+--^--+   |
+#           |   | sum |--->-10- out_0
+# in_a1  -7->---+--+--+   |
+#           |      |      |
+# in_c   -9->------+      |
+#           |             |
+#        -8-+- ign   ign -+-16-
+#           |             |
+#           +-------------+                                                          
+
+.chipsets:
+input in_a1
+input in_a2
+input in_a3
+input in_a4
+input in_b1
+input in_b2
+input in_b3
+input in_b4
+input in_c
+output out_0
+output out_1
+output out_2
+output out_3
+output out_c
+4008 adder
+
+.links:
+in_a1:1 adder:7
+in_a2:1 adder:5
+in_a3:1 adder:3
+in_a4:1 adder:1
+in_b1:1 adder:6
+in_b2:1 adder:4
+in_b3:1 adder:2
+in_b4:1 adder:15
+in_c:1 adder:9
+out_0:1 adder:10
+out_1:1 adder:11
+out_2:1 adder:12
+out_3:1 adder:13
+out_c:1 adder:14

--- a/tests/Comp/nts_single/4011_nand.nts
+++ b/tests/Comp/nts_single/4011_nand.nts
@@ -1,0 +1,46 @@
+# NAND logic gates (4011)
+#
+#           +----------4011----------+
+# in_01  -1-|>-+---\         ignored-|-14-
+#           |  | &  |o-+             |
+# in_02  -2-|>-+---/   |      /---+-<|-13- in_13
+#           |          |  +-o|  & |  |
+# out_03 -3-|<---------+   |  \---+-<|-12- in_12
+#           |              |         |
+# out_04 -4-|<---------+  +--------->|-11- out_11
+#           |          |             |
+# in_05  -5-|>-+---\   |  +--------->|-10- out_10
+#           |  | &  |o-+  |          |
+# in_06  -6-|>-+---/      |   /---+-<|-9-  in_09
+#           |             +-o|  & |  |
+#        -7-|-ignored         \---+-<|-8-  in_08
+#           +------------------------+
+
+.chipsets:
+input in_01
+input in_02
+output out_03
+output out_04
+input in_05
+input in_06
+input in_08
+input in_09
+output out_10
+output out_11
+input in_12
+input in_13
+4011 gate
+
+.links:
+in_01:1 gate:1
+in_02:1 gate:2
+out_03:1 gate:3
+out_04:1 gate:4
+in_05:1 gate:5
+in_06:1 gate:6
+in_08:1 gate:8
+in_09:1 gate:9
+out_10:1 gate:10
+out_11:1 gate:11
+in_12:1 gate:12
+in_13:1 gate:13

--- a/tests/Comp/nts_single/4013_flipflop.nts
+++ b/tests/Comp/nts_single/4013_flipflop.nts
@@ -1,0 +1,58 @@
+# Dual D-Type Flip-Flop (4013)
+#
+#     cl_1_clock  -3-+
+#                    |
+#                +---v---+
+#                |   |   |
+#                | +-v-+ |
+#                | |   | |
+# in_1_data   -5->-> L | |
+#                | | A >->-1-  out_1_q
+# in_1_set    -6->-> T | |
+#                | | C >->-2-  out_1_qb
+# in_1_reset  -4->-> H | |
+#                | |   | |
+#                | +---+ |
+#                |       |
+#                | +---+ |
+#                | |   | |
+# in_2_data   -9->-> L | |
+#                | | A >->-13- out_2_q
+# in_2_set    -8->-> T | |
+#                | | C >->-12- out_2_qb
+# in_2_reset -10->-> H | |
+#                | |   | |
+#                | +-^-+ |
+#                |   |   |
+#                +---^---+
+#                    |
+#     cl_2_clock -11-+
+
+.chipsets:
+clock cl_1_clock
+input in_1_data
+input in_1_set
+input in_1_reset
+output out_1_q
+output out_1_qb
+clock cl_2_clock
+input in_2_data
+input in_2_set
+input in_2_reset
+output out_2_q
+output out_2_qb
+4013 flipflop
+
+.links:
+cl_1_clock:1 flipflop:3
+in_1_data:1 flipflop:5
+in_1_set:1 flipflop:6
+in_1_reset:1 flipflop:4
+out_1_q:1 flipflop:1
+out_1_qb:1 flipflop:2
+cl_2_clock:1 flipflop:11
+in_2_data:1 flipflop:9
+in_2_set:1 flipflop:8
+in_2_reset:1 flipflop:10
+out_2_q:1 flipflop:13
+out_2_qb:1 flipflop:12

--- a/tests/Comp/nts_single/4017_johnson.nts
+++ b/tests/Comp/nts_single/4017_johnson.nts
@@ -1,0 +1,50 @@
+# Johnson Decade Counter (4017)
+#
+#          +-4017----------------+
+#          |                     |
+# in_0 -14->                     |
+#          |   JOHNSON DECADE    |
+# in_1 -13->       COUNTER       |
+#          |                     |
+# in_r -15->                     >-12- out_s
+#          |                     |
+#          +-v-v-v-v-v-v-v-v-v-v-+
+#            | | | | | | | | | |
+#   out_0 -3-+ | | | | | | | | +-11- out_9
+#     out_1 -2-+ | | | | | | +-9- out_8
+#       out_2 -4-+ | | | | +-6- out_7
+#         out_3 -7-+ | | +-5- out_6
+#          out_4 -10-+ +-1- out_5
+
+.chipsets:
+input in_0
+input in_1
+input in_r
+output out_0
+output out_1
+output out_2
+output out_3
+output out_4
+output out_5
+output out_6
+output out_7
+output out_8
+output out_9
+output out_s
+4017 johnson
+
+.links:
+in_0:1 johnson:14
+in_1:1 johnson:13
+in_r:1 johnson:15
+out_0:1 johnson:3
+out_1:1 johnson:2
+out_2:1 johnson:4
+out_3:1 johnson:7
+out_4:1 johnson:10
+out_5:1 johnson:1
+out_6:1 johnson:5
+out_7:1 johnson:6
+out_8:1 johnson:9
+out_9:1 johnson:11
+out_s:1 johnson:12

--- a/tests/Comp/nts_single/4030_xor.nts
+++ b/tests/Comp/nts_single/4030_xor.nts
@@ -1,0 +1,46 @@
+# XOR logic gates (4030)
+#
+#           +---------4030---------+
+# in_01  -1-|>-+---\       ignored-|-14-
+#           |  |xor |-+            |
+# in_02  -2-|>-+---/  |     /---+-<|-13- in_13
+#           |         |  +-| xor|  |
+# out_03 -3-|<--------+  |  \---+-<|-12- in_12
+#           |            |         |
+# out_04 -4-|<--------+  +-------->|-11- out_11
+#           |         |            |
+# in_05  -5-|>-+---\  |  +-------->|-10- out_10
+#           |  |xor |-+  |         |
+# in_06  -6-|>-+---/     |  /---+-<|-9-  in_09
+#           |            +-| xor|  |
+#        -7-|-ignored       \---+-<|-8-  in_08
+#           +----------------------+
+
+.chipsets:
+input in_01
+input in_02
+output out_03
+output out_04
+input in_05
+input in_06
+input in_08
+input in_09
+output out_10
+output out_11
+input in_12
+input in_13
+4030 gate
+
+.links:
+in_01:1 gate:1
+in_02:1 gate:2
+out_03:1 gate:3
+out_04:1 gate:4
+in_05:1 gate:5
+in_06:1 gate:6
+in_08:1 gate:8
+in_09:1 gate:9
+out_10:1 gate:10
+out_11:1 gate:11
+in_12:1 gate:12
+in_13:1 gate:13

--- a/tests/Comp/nts_single/4040_counter.nts
+++ b/tests/Comp/nts_single/4040_counter.nts
@@ -1,0 +1,47 @@
+# 12-bits Binary Counter (4040)
+#
+#      cl_clock -10-+     +-11- in_reset
+#                   |     |
+#    +------4040----v-----v--------------+
+# -8-|-ign   12-bit Binary Counter   ign-|-16-
+#    +------v-v-v-v-v-v-v-v-v-v-v-v------+
+#           | | | | | | | | | | | |
+# out_00 -9-+ | | | | | | | | | | +-1- out_11
+#   out_01 -7-+ | | | | | | | | +-15- out_10
+#     out_02 -6-+ | | | | | | +-14- out_09
+#       out_03 -5-+ | | | | +-12- out_08
+#         out_04 -3-+ | | +-13- out_07
+#           out_05 -2-+ +-4- out_06
+
+.chipsets:
+clock cl_clock
+input in_reset
+output out_00
+output out_01
+output out_02
+output out_03
+output out_04
+output out_05
+output out_06
+output out_07
+output out_08
+output out_09
+output out_10
+output out_11
+4040 counter
+
+.links:
+cl_clock:1 counter:10
+in_reset:1 counter:11
+out_00:1 counter:9
+out_01:1 counter:7
+out_02:1 counter:6
+out_03:1 counter:5
+out_04:1 counter:3
+out_05:1 counter:2
+out_06:1 counter:4
+out_07:1 counter:13
+out_08:1 counter:12
+out_09:1 counter:14
+out_10:1 counter:15
+out_11:1 counter:1

--- a/tests/Comp/nts_single/4069_not.nts
+++ b/tests/Comp/nts_single/4069_not.nts
@@ -1,0 +1,58 @@
+# NOT logic gates (4069)
+#
+#           +----4069----+
+# in_01  -1-|>--+    ign-|-14-
+#           |  _|_       |
+#           |  \ /   +--<|-13- in_13
+#           |   v   _|_  |
+#           |   O   \ /  |
+#           |   |    v   |
+# out_02 -2-|<--+    O   |
+#           |        |   |
+# in_03  -3-|>--+    +-->|-12- out_12
+#           |  _|_       |
+#           |  \ /   +--<|-11- in_11
+#           |   v   _|_  |
+#           |   O   \ /  |
+#           |   |    v   |
+# out_04 -4-|<--+    O   |
+#           |        |   |
+# in_05  -5-|>--+    +-->|-10- out_10
+#           |  _|_       |
+#           |  \ /   +--<|-9-  in_09
+#           |   v   _|_  |
+#           |   O   \ /  |
+#           |   |    v   |
+# out_06 -6-|<--+    O   |
+#           |        |   |
+#        -7-|-ign    +-->|-8-  out_08
+#           +------------+
+
+.chipsets:
+input in_01
+output out_02
+input in_03
+output out_04
+input in_05
+output out_06
+output out_08
+input in_09
+output out_10
+input in_11
+output out_12
+input in_13
+4069 gate
+
+.links:
+in_01:1 gate:1
+out_02:1 gate:2
+in_03:1 gate:3
+out_04:1 gate:4
+in_05:1 gate:5
+out_06:1 gate:6
+out_08:1 gate:8
+in_09:1 gate:9
+out_10:1 gate:10
+in_11:1 gate:11
+out_12:1 gate:12
+in_13:1 gate:13

--- a/tests/Comp/nts_single/4071_or.nts
+++ b/tests/Comp/nts_single/4071_or.nts
@@ -1,0 +1,46 @@
+# OR logic gates (4071)
+#
+#           +---------4071---------+
+# in_01  -1-|>-+---\       ignored-|-14-
+#           |  | or |-+            |
+# in_02  -2-|>-+---/  |     /---+-<|-13- in_13
+#           |         |  +-| or |  |
+# out_03 -3-|<--------+  |  \---+-<|-12- in_12
+#           |            |         |
+# out_04 -4-|<--------+  +-------->|-11- out_11
+#           |         |            |
+# in_05  -5-|>-+---\  |  +-------->|-10- out_10
+#           |  | or |-+  |         |
+# in_06  -6-|>-+---/     |  /---+-<|-9-  in_09
+#           |            +-| or |  |
+#        -7-|-ignored       \---+-<|-8-  in_08
+#           +----------------------+
+
+.chipsets:
+input in_01
+input in_02
+output out_03
+output out_04
+input in_05
+input in_06
+input in_08
+input in_09
+output out_10
+output out_11
+input in_12
+input in_13
+4071 gate
+
+.links:
+in_01:1 gate:1
+in_02:1 gate:2
+out_03:1 gate:3
+out_04:1 gate:4
+in_05:1 gate:5
+in_06:1 gate:6
+in_08:1 gate:8
+in_09:1 gate:9
+out_10:1 gate:10
+out_11:1 gate:11
+in_12:1 gate:12
+in_13:1 gate:13

--- a/tests/Comp/nts_single/4081_and.nts
+++ b/tests/Comp/nts_single/4081_and.nts
@@ -1,0 +1,46 @@
+# Test of AND logic gate (4081)
+#
+#           +---------4081---------+
+# in_01  -1-|>-+---\       ignored-|-14-
+#           |  | &  |-+            |
+# in_02  -2-|>-+---/  |     /---+-<|-13- in_13
+#           |         |  +-|  & |  |
+# out_03 -3-|<--------+  |  \---+-<|-12- in_12
+#           |            |         |
+# out_04 -4-|<--------+  +-------->|-11- out_11
+#           |         |            |
+# in_05  -5-|>-+---\  |  +-------->|-10- out_10
+#           |  | &  |-+  |         |
+# in_06  -6-|>-+---/     |  /---+-<|-9-  in_09
+#           |            +-|  & |  |
+#        -7-|-ignored       \---+-<|-8-  in_08
+#           +----------------------+
+
+.chipsets:
+input in_01
+input in_02
+output out_03
+output out_04
+input in_05
+input in_06
+input in_08
+input in_09
+output out_10
+output out_11
+input in_12
+input in_13
+4081 gate
+
+.links:
+in_01:1 gate:1
+in_02:1 gate:2
+out_03:1 gate:3
+out_04:1 gate:4
+in_05:1 gate:5
+in_06:1 gate:6
+in_08:1 gate:8
+in_09:1 gate:9
+out_10:1 gate:10
+out_11:1 gate:11
+in_12:1 gate:12
+in_13:1 gate:13

--- a/tests/Comp/nts_single/4094_shift.nts
+++ b/tests/Comp/nts_single/4094_shift.nts
@@ -1,0 +1,57 @@
+# 8-bits Shift Register (4094)
+#
+#                   out_3 -7-+   +-14- out_4
+#               out_2 -6-+   |   |   +-13- out_5
+#           out_1 -5-+   |   |   |   |   +-12- out_6
+#       out_0 -4-+   |   |   |   |   |   |   +-11- out_7
+#                |   |   |   |   |   |   |   |
+#            +---^---^---^---^---^---^---^---^---+
+#            |   |   |   |   |   |   |   |   |   |
+# enable -15->--[/]-[/]-[/]-[/]-[/]-[/]-[/]-[/]  |
+#            |   |   |   |   |   |   |   |   |   |
+#            |  +-----------------------------+  |
+#            |  |         saved value         |  |
+#            |  +-----------------------------+  |
+#            |   |   |   |   |   |   |   |   |   |
+#  strobe -1->--[/]-[/]-[/]-[/]-[/]-[/]-[/]-[/]  |
+#            |   |   |   |   |   |   |   |   |   |
+#            |  +-----------------------------+  |
+#    data -2->-->    8 bits shift register    >-->-9- out_qs
+#            |  +-^-------------------------v-+  |
+#            |    |                         |    |
+#   clock -3->----+                         +---->-10- out_qe
+#            |                                   |
+#            +-4094------------------------------+
+
+.chipsets:
+clock clock
+input data
+true strobe
+true enable
+output out_0
+output out_1
+output out_2
+output out_3
+output out_4
+output out_5
+output out_6
+output out_7
+output out_qs
+output out_qe
+4094 shift
+
+.links:
+clock:1 shift:3
+data:1 shift:2
+strobe:1 shift:1
+enable:1 shift:15
+out_0:1 shift:4
+out_1:1 shift:5
+out_2:1 shift:6
+out_3:1 shift:7
+out_4:1 shift:14
+out_5:1 shift:13
+out_6:1 shift:12
+out_7:1 shift:11
+out_qs:1 shift:9
+out_qe:1 shift:10

--- a/tests/Comp/nts_single/4512_selector.nts
+++ b/tests/Comp/nts_single/4512_selector.nts
@@ -1,0 +1,51 @@
+# 8 Channel Data Selector (4512)
+#
+#          in_3 -4-+ +-5- in_4
+#        in_2 -3-+ | | +-6- in_5
+#      in_1 -2-+ | | | | +-7- in_6
+#    in_0 -1-+ | | | | | | +-9- in_7
+#            | | | | | | | |
+#          +-v-v-v-v-v-v-v-v-+
+#          |                 |
+# in_a -11->                 <-10- inhibit
+#          |                 |
+# in_b -12->                 |
+#          |                 |
+# in_c -13->                 <-15- enable
+#          |                 |
+#          +-4512---v--------+
+#                   |
+#                   +-14- out_data
+
+.chipsets:
+input in_a
+input in_b
+input in_c
+input in_0
+input in_1
+input in_2
+input in_3
+input in_4
+input in_5
+input in_6
+input in_7
+input inhibit
+input enable
+output out_data
+4512 selector
+
+.links:
+in_a:1 selector:11
+in_b:1 selector:12
+in_c:1 selector:13
+in_0:1 selector:1
+in_1:1 selector:2
+in_2:1 selector:3
+in_3:1 selector:4
+in_4:1 selector:5
+in_5:1 selector:6
+in_6:1 selector:7
+in_7:1 selector:9
+inhibit:1 selector:10
+enable:1 selector:15
+out_data:1 selector:14

--- a/tests/Comp/nts_single/4514_decoder.nts
+++ b/tests/Comp/nts_single/4514_decoder.nts
@@ -1,0 +1,76 @@
+# 4-bits Decoder (4514)
+#
+#                              +-11- out_00
+#                              |   +-09- out_01
+#                              |   |   +-10- out_02
+#                              |   |   |   +-08- out_03
+#                              |   |   |   |   +-07- out_04
+#              inhibit -23-+   |   |   |   |   |   +-06- out_05
+#                          |   |   |   |   |   |   |
+#          +---4514--------v---^---^---^---^---^---^-------+
+#          |               |   |   |   |   |   |   |       |
+# in_0  -2->---+---+---+---+---+---+---+---+---+---+---+--->-05- out_06
+#          |   | L |   |                               |   |
+# in_1  -3->---| A |---|                               +--->-04- out_07
+#          |   | T |   |        4-to-16 DECODER        |   |
+# in_2 -21->---| C |---|                               +--->-18- out_08
+#          |   | H |   |                               |   |
+# in_3 -22->---+---+---+-------+---+---+---+---+---+---+--->-17- out_09
+#          |     |  ign ign    |   |   |   |   |   |       |
+#          +-----^---+---+-----v---v---v---v---v---v-------+
+#                |   |   |     |   |   |   |   |   |
+#      strobe -1-+   |   |     |   |   |   |   |   +-20- out_10
+#                -12-+   |     |   |   |   |   +-19- out_11
+#                    -24-+     |   |   |   +-14- out_12
+#                              |   |   +-13- out_13
+#                              |   +-16- out_14
+#                              +-15- out_15
+
+.chipsets:
+input in_0
+input in_1
+input in_2
+input in_3
+input strobe
+input inhibit
+output out_00
+output out_01
+output out_02
+output out_03
+output out_04
+output out_05
+output out_06
+output out_07
+output out_08
+output out_09
+output out_10
+output out_11
+output out_12
+output out_13
+output out_14
+output out_15
+4514 decoder
+
+.links:
+in_0:1 decoder:2
+in_1:1 decoder:3
+in_2:1 decoder:21
+in_3:1 decoder:22
+strobe:1 decoder:1
+inhibit:1 decoder:23
+out_00:1 decoder:11
+out_01:1 decoder:9
+out_02:1 decoder:10
+out_03:1 decoder:8
+out_04:1 decoder:7
+out_05:1 decoder:6
+out_06:1 decoder:5
+out_07:1 decoder:4
+out_08:1 decoder:18
+out_09:1 decoder:17
+out_10:1 decoder:20
+out_11:1 decoder:19
+out_12:1 decoder:14
+out_13:1 decoder:13
+out_14:1 decoder:16
+out_15:1 decoder:15

--- a/tests/Comp/nts_single/4801_ram.nts
+++ b/tests/Comp/nts_single/4801_ram.nts
@@ -1,0 +1,85 @@
+# 1024 Bytes RAM (4801)
+#
+#            addr_4 -4-+ +-3- addr_5
+#          addr_3 -5-+ | | +-2- addr_6
+#        addr_2 -6-+ | | | | +-1- addr_7
+#      addr_1 -7-+ | | | | | | +-23- addr_8
+#    addr_0 -8-+ | | | | | | | | +-22- addr_9
+#              | | | | | | | | | |
+#            +-v-v-v-v-v-v-v-v-v-v-+
+#            |                     |
+# enable -18->                ign -<-12-
+#            |                     |
+#  write -21->                ign -<-19-
+#            |                     |
+#   read -20->                ign -<-24-
+#            | 4801 RAM            |
+#            +---o-o-o-o-o-o-o-o---+
+#                | | | | | | | |       
+#    in/out_0 -9-+ | | | | | | +-17- in/out_7
+#     in/out_1 -10-+ | | | | +-16- in/out_6
+#       in/out_2 -11-+ | | +-15- in/out_5
+#         in/out_3 -13-+ +-15- in/out_4
+
+.chipsets:
+input enable
+input write
+input read
+input addr_0
+input addr_1
+input addr_2
+input addr_3
+input addr_4
+input addr_5
+input addr_6
+input addr_7
+input addr_8
+input addr_9
+input in_0
+input in_1
+input in_2
+input in_3
+input in_4
+input in_5
+input in_6
+input in_7
+output out_0
+output out_1
+output out_2
+output out_3
+output out_4
+output out_5
+output out_6
+output out_7
+4801 ram
+
+.links:
+enable:1 ram:18
+write:1 ram:21
+read:1 ram:20
+addr_0:1 ram:8
+addr_1:1 ram:7
+addr_2:1 ram:6
+addr_3:1 ram:5
+addr_4:1 ram:4
+addr_5:1 ram:3
+addr_6:1 ram:2
+addr_7:1 ram:1
+addr_8:1 ram:23
+addr_9:1 ram:22
+in_0:1 ram:9
+in_1:1 ram:10
+in_2:1 ram:11
+in_3:1 ram:13
+in_4:1 ram:14
+in_5:1 ram:15
+in_6:1 ram:16
+in_7:1 ram:17
+out_0:1 ram:9
+out_1:1 ram:10
+out_2:1 ram:11
+out_3:1 ram:13
+out_4:1 ram:14
+out_5:1 ram:15
+out_6:1 ram:16
+out_7:1 ram:17

--- a/tests/Comp/nts_single/and.nts
+++ b/tests/Comp/nts_single/and.nts
@@ -1,0 +1,16 @@
+# Basic AND logic gate
+#
+# in_1  -1-+---\
+#          | &  |-3- out
+# in_2  -2-+---/
+
+.chipsets:
+input in_1
+input in_2
+output out
+and gate
+
+.links:
+in_1:1 gate:1
+in_2:1 gate:2
+out:1 gate:3

--- a/tests/Comp/nts_single/clock.nts
+++ b/tests/Comp/nts_single/clock.nts
@@ -1,0 +1,10 @@
+# Basic wire, direct link clock to output.
+#
+# CLOCK ---> OUTPUT
+
+.chipsets:
+clock cl
+output out
+
+.links:
+cl:1 out:1

--- a/tests/Comp/nts_single/false.nts
+++ b/tests/Comp/nts_single/false.nts
@@ -1,0 +1,10 @@
+# Basic wire, direct link false to output.
+#
+# FALSE ---> OUTPUT
+
+.chipsets:
+false in
+output out
+
+.links:
+in:1 out:1

--- a/tests/Comp/nts_single/input_output.nts
+++ b/tests/Comp/nts_single/input_output.nts
@@ -1,0 +1,10 @@
+# Basic wire, direct link input to output.
+#
+# INPUT ---> OUTPUT
+
+.chipsets:
+input in
+output out
+
+.links:
+in:1 out:1

--- a/tests/Comp/nts_single/logger.nts
+++ b/tests/Comp/nts_single/logger.nts
@@ -1,0 +1,48 @@
+# Byte Logger Component
+#
+#           +-Logger-+
+#           |        |
+# in_001 -1->        |
+#           |        |
+# in_002 -2->        |
+#           |        |
+# in_004 -3->        |
+#           |        |
+# in_008 -4->        |
+#           |        |
+# in_016 -5->        |
+#           |        |
+# in_032 -6->        |
+#           |        |
+# in_064 -7->        |
+#           |        |
+# in_128 -8->        |
+#           |        |
+#           +-^----^-+
+#             |    |
+#    clock -9-+    +-10- inhibit
+
+.chipsets:
+input in_001
+input in_002
+input in_004
+input in_008
+input in_016
+input in_032
+input in_064
+input in_128
+clock clock
+input inhibit
+logger logger
+
+.links:
+in_001:1 logger:1
+in_002:1 logger:2
+in_004:1 logger:3
+in_008:1 logger:4
+in_016:1 logger:5
+in_032:1 logger:6
+in_064:1 logger:7
+in_128:1 logger:8
+clock:1 logger:9
+inhibit:1 logger:10

--- a/tests/Comp/nts_single/not.nts
+++ b/tests/Comp/nts_single/not.nts
@@ -1,0 +1,12 @@
+# Basic NOT logic gate
+#
+# in -1-|>o-2- out
+
+.chipsets:
+input in
+output out
+not gate
+
+.links:
+in:1 gate:1
+out:1 gate:2

--- a/tests/Comp/nts_single/or.nts
+++ b/tests/Comp/nts_single/or.nts
@@ -1,0 +1,16 @@
+# Basic OR logic gate
+#
+# in_1  -1-+---\
+#          | or |-3- out
+# in_2  -2-+---/
+
+.chipsets:
+input in_1
+input in_2
+output out
+or gate
+
+.links:
+in_1:1 gate:1
+in_2:1 gate:2
+out:1 gate:3

--- a/tests/Comp/nts_single/true.nts
+++ b/tests/Comp/nts_single/true.nts
@@ -1,0 +1,10 @@
+# Basic wire, direct link true to output.
+#
+# TRUE ---> OUTPUT
+
+.chipsets:
+true in
+output out
+
+.links:
+in:1 out:1

--- a/tests/Comp/nts_single/xor.nts
+++ b/tests/Comp/nts_single/xor.nts
@@ -1,0 +1,16 @@
+# Basic XOR logic gate
+#
+# in_1  -1-+---\
+#          |xor |-3- out
+# in_2  -2-+---/
+
+.chipsets:
+input in_1
+input in_2
+output out
+xor gate
+
+.links:
+in_1:1 gate:1
+in_2:1 gate:2
+out:1 gate:3


### PR DESCRIPTION
This pull request introduces a new script for testing `nanotekspice` executable and adds several new test files for various components. The script automates the process of finding and running tests on `.nts` files, and logs the results.

New script for testing:

* [`script.sh`](diffhunk://#diff-116b4e2bac3e35befdfae3f3b6eb88911689c30bfe6696d9e6b0139da8cb5e72R1-R85): Added a new Bash script to automate the testing of `.nts` files using the `nanotekspice` executable. The script includes functionalities for setting the test directory, checking for the existence of the executable, finding `.nts` files, running tests with timeout, and logging results.

New test files for various components:

* [`tests/Comp/bad.nts`](diffhunk://#diff-c2b8bad881b8a42253a623356c55b3a8e5643c7ad2c8e0f55ad92965c9f8765cR1-R5): Added a test file with a missing link between components.
* [`tests/Comp/missing_links.nts`](diffhunk://#diff-68df13a19e7124857cb868c9e12686012d0a3288ca1f71d1fd6add015b4545fbR1-R3): Added a test file with missing links between components.
* [`tests/Comp/nts_advanced/altered-counter.nts`](diffhunk://#diff-6275275c331c3b3ecf38774276812ebc04d84e05691d06779f9eb639900e2dc1R1-R45): Added a test file for an altered counter circuit.
* [`tests/Comp/nts_advanced/and-or-not.nts`](diffhunk://#diff-8078ffc9adcd6279d7fd9c91d991fd6f60e56c93332358f04ae8ad09db93a333R1-R30): Added a test file combining OR, AND, and NOT gates.
* [`tests/Comp/nts_advanced/and.nts`](diffhunk://#diff-acf2f6c75367849bdd4e7015b1ed27b770f16bd2100109cc85567de187cb8847R1-R31): Added a test file for a combinatory AND circuit.
* [`tests/Comp/nts_single/2716_rom.nts`](diffhunk://#diff-67a1127ee68935c4274817dc3ec282e8b1e3948de5dd609dd4f5b90e0dfc968fR1-R70): Added a test file for a 2048 Bytes ROM (2716).
* [`tests/Comp/nts_single/4001_nor.nts`](diffhunk://#diff-0854fbfdc9efa66d733bb3a00771fe90849e1e01eb12a9bd7b58effc71d70585R1-R46): Added a test file for NOR logic gates (4001).
* [`tests/Comp/nts_single/4008_adder.nts`](diffhunk://#diff-a633194247a3e00e4c0f824bf5b79fa5d8adf34350cfaffaaf23eb5e1bec1040R1-R60): Added a test file for a 4-bits Adder (4008).
* [`tests/Comp/nts_single/4011_nand.nts`](diffhunk://#diff-f3a9436920884be90f6a0b6761d8d5ac8e4cb87340fea576332861c359a11991R1-R46): Added a test file for NAND logic gates (4011).
* [`tests/Comp/nts_single/4013_flipflop.nts`](diffhunk://#diff-155d149b4338d1b44d1acf96ac6df566246d23181cf4590ecb7ad7cb70d16bcbR1-R58): Added a test file for a Dual D-Type Flip-Flop (4013).
* [`tests/Comp/nts_single/4017_johnson.nts`](diffhunk://#diff-d84e26d9fb52f28c0d711c18ea712d89e40ea276b0b200bea5775b5f3a31fe03R1-R50): Added a test file for a Johnson Decade Counter (4017).
* [`tests/Comp/nts_single/4030_xor.nts`](diffhunk://#diff-72d16bf1ae9260d578675612bc3ee6a8baf9cfd943410a677f5900f70a852490R1-R46): Added a test file for XOR logic gates (4030).
* [`tests/Comp/nts_single/4040_counter.nts`](diffhunk://#diff-dda252a69e354472804f9c6e174467a2c4b77f1799b935e80619a925b86562a4R1-R47): Added a test file for a 12-bits Binary Counter (4040).
* [`tests/Comp/nts_single/4069_not.nts`](diffhunk://#diff-2b3ebae7cbf53007ab4d1b2c89aecaf079b238d607cd6978fb783edec5933a05R1-R58): Added a test file for NOT logic gates (4069).
* [`tests/Comp/nts_single/4071_or.nts`](diffhunk://#diff-79c0c5b884203ac6d0582840456f5b8bf87342e7c693fb08e9730dce510db7e1R1-R46): Added a test file for OR logic gates (4071).
* [`tests/Comp/nts_single/4081_and.nts`](diffhunk://#diff-b8b16761a677a251f7db848386ebb31812f4bdd586e5004a51ac4118ecbd013fR1-R46): Added a test file for AND logic gates (4081).
* [`tests/Comp/nts_single/4094_shift.nts`](diffhunk://#diff-337b0e740ba682501e4177eaedb152c29382bb9c4f6cf92a1fe60438c24f17caR1-R57): Added a test file for an 8-bits Shift Register (4094).![image](https://github.com/user-attachments/assets/f6dd08ed-44fe-46fd-a390-7345c8794782)
