### PR TITLE
[REFINE] add Clock component

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ MAIN 	= 		$(SRC_DIR)/main.cpp
 
 TEST_SRC = 		tests/test.cpp \
 				tests/test_special_components.cpp \
-				tests/test_circuit.cpp
+				tests/test_circuit.cpp	\
+				tests/test_clock.cpp
 
 
 OBJ = $(SRC:.cpp=.o)

--- a/include/Circuit.hpp
+++ b/include/Circuit.hpp
@@ -36,6 +36,7 @@ namespace nts
         private:
             mutable size_t _tick;
 		    std::vector<nts::OutputComponent*> _outputs;
+            mutable std::vector<std::shared_ptr<nts::IComponent>> _tempComponents;
             std::unordered_map<std::string, std::shared_ptr<nts::IComponent>> _components;
             Factory _factory;
             void displayComponentState(const std::string& name, nts::Tristate state) const;

--- a/include/specialComponents/Clock.hpp
+++ b/include/specialComponents/Clock.hpp
@@ -21,6 +21,7 @@ namespace nts
 
         private:
             size_t _lastTick;
+            bool _manuallySet = true;
     };
 }
 

--- a/src/Circuit.cpp
+++ b/src/Circuit.cpp
@@ -52,15 +52,16 @@ void nts::Circuit::displayInputs() const
 {
     for (const auto &component : _components)
     {
-        auto input = dynamic_cast<nts::InputComponent *>(component.second.get());
-        if (input != nullptr)
-        {
-            displayComponentState(input->getName(), input->getState());
-        }
         auto clock = dynamic_cast<nts::ClockComponent *>(component.second.get());
         if (clock != nullptr)
         {
             displayComponentState(clock->getName(), clock->getState());
+            continue;
+        }
+        auto input = dynamic_cast<nts::InputComponent *>(component.second.get());
+        if (input != nullptr)
+        {
+            displayComponentState(input->getName(), input->getState());
         }
         auto trueComponent = dynamic_cast<nts::TrueComponent *>(component.second.get());
         if (trueComponent != nullptr)
@@ -107,14 +108,16 @@ void nts::Circuit::setInputState(nts::InputComponent &input, nts::Tristate state
 {
     if (state == input.getState())
         return;
-    if (state == nts::UNDEFINED)
-        input.setLink(1, _factory.createComponent("undefined", "undefined"), 1);
-    else if (state == nts::TRUE)
-        input.setLink(1, _factory.createComponent("true", "true"), 1);
-    else
-        input.setLink(1, _factory.createComponent("false", "false"), 1);
 
-    input.simulate(_tick);
+    std::shared_ptr<nts::IComponent> tempComponent;
+    if (state == nts::UNDEFINED)
+        tempComponent = _factory.createComponent("undefined", "undefined");
+    else if (state == nts::TRUE)
+        tempComponent = _factory.createComponent("true", "true");
+    else
+        tempComponent = _factory.createComponent("false", "false");
+    _tempComponents.push_back(tempComponent);
+    input.setLink(1, tempComponent, 1);
 }
 
 std::shared_ptr<nts::IComponent> &nts::Circuit::getComponent(const std::string &name)

--- a/src/specialComponents/Clock.cpp
+++ b/src/specialComponents/Clock.cpp
@@ -13,29 +13,38 @@ nts::ClockComponent::ClockComponent(const std::string &name) : InputComponent(na
     this->_lastTick = 0;
 }
 
-void nts::ClockComponent::setLink(std::size_t pin, std::shared_ptr<nts::IComponent> other, std::size_t otherPin)
+void nts::ClockComponent::setLink(std::size_t pin, ComponentPtr other, std::size_t otherPin)
 {
     (void)otherPin;
     if (pin == 1)
-        this->_pins[pin - 1] = other; // This stores a weak_ptr now
+        this->_pins[pin - 1] = other;
     else
         throw std::invalid_argument("Pin does not exist");
+    _manuallySet = true;
 }
 
 void nts::ClockComponent::simulate(std::size_t tick)
 {
-    auto pin = this->_pins[0].lock();
-    if (!pin)
-        throw std::invalid_argument("Pin not linked or component destroyed");
-    if (tick == this->_lastTick) {
-        std::cerr << "ClockComponent::simulate called twice with the same tick" << std::endl;
+    if (tick == this->_lastTick)
         return;
-    }
     this->_lastTick = tick;
-    if (this->getState() == nts::TRUE)
-        this->setState(nts::FALSE);
-    else
-        this->setState(nts::TRUE);
+    if (this->_pins[0].lock()) {
+        nts::Tristate newState = this->_pins[0].lock()->compute(tick);
+        if (this->getState() == nts::UNDEFINED || this->_manuallySet) {
+            this->setState(newState);
+            this->_manuallySet = false;
+        } else {
+            if (this->getState() == nts::TRUE)
+                this->setState(nts::FALSE);
+            else
+                this->setState(nts::TRUE);
+        }
+    } else {
+        if (this->getState() == nts::TRUE)
+            this->setState(nts::FALSE);
+        else if (this->getState() == nts::FALSE)
+            this->setState(nts::TRUE);
+    }
 }
 
 nts::Tristate nts::ClockComponent::compute(std::size_t tick)

--- a/tests/test_clock.cpp
+++ b/tests/test_clock.cpp
@@ -1,0 +1,111 @@
+/*
+** EPITECH PROJECT, 2025
+** nanoTekSpice
+** File description:
+** Clock Component Tests
+*/
+
+#include <criterion/criterion.h>
+#include <criterion/redirect.h>
+#include "../include/specialComponents/Clock.hpp"
+#include "../include/Factory.hpp"
+
+// Mock component for testing
+class MockComponent : public nts::IComponent {
+public:
+    MockComponent() : state(nts::UNDEFINED) {}
+    ~MockComponent() = default;
+
+    nts::Tristate compute(std::size_t tick) override {
+        (void)tick;
+        return state;
+    }
+
+    void setLink(std::size_t pin, std::shared_ptr<nts::IComponent> other, std::size_t otherPin) override {
+        (void)pin;
+        (void)other;
+        (void)otherPin;
+    }
+
+    void simulate(std::size_t tick) override {
+        (void)tick;
+    }
+
+    void setState(nts::Tristate newState) {
+        state = newState;
+    }
+
+    // Added implementations for abstract functions
+    nts::Tristate getState() const override {
+        return state;
+    }
+
+    const std::string &getName() const override {
+        static const std::string name = "MockComponent";
+        return name;
+    }
+
+private:
+    nts::Tristate state;
+};
+
+Test(ClockComponent, initialization) {
+    nts::ClockComponent clock("clock");
+    cr_assert_eq(clock.getState(), nts::UNDEFINED, "Initial clock state should be UNDEFINED");
+}
+
+Test(ClockComponent, setLink_valid) {
+    nts::ClockComponent clock("clock");
+    auto mock = std::make_shared<MockComponent>();
+
+    // Should not throw
+    try {
+        clock.setLink(1, mock, 1);
+        cr_assert(true, "Setting link to pin 1 should not throw");
+    } catch (const std::exception &e) {
+        cr_assert(false, "Setting link to pin 1 should not throw but threw: %s", e.what());
+    }
+}
+
+Test(ClockComponent, setLink_invalid) {
+    nts::ClockComponent clock("clock");
+    auto mock = std::make_shared<MockComponent>();
+
+    // Should throw for invalid pin
+    cr_assert_throw(clock.setLink(2, mock, 1), std::invalid_argument, "Setting link to invalid pin should throw");
+}
+
+Test(ClockComponent, simulate_toggle) {
+    nts::ClockComponent clock("clock");
+
+    // Set initial state
+    clock.setState(nts::TRUE);
+    cr_assert_eq(clock.getState(), nts::TRUE, "Initial state should be TRUE");
+
+    // First simulate call should toggle state
+    clock.simulate(1);
+    cr_assert_eq(clock.getState(), nts::FALSE, "State should toggle to FALSE after simulate");
+
+    // Second simulate call should toggle state again
+    clock.simulate(2);
+    cr_assert_eq(clock.getState(), nts::TRUE, "State should toggle to TRUE after simulate");
+
+    // Simulate with same tick should not change state
+    clock.simulate(2);
+    cr_assert_eq(clock.getState(), nts::TRUE, "State should not change when tick is the same");
+}
+
+Test(ClockComponent, compute) {
+    nts::ClockComponent clock("clock");
+
+    // Set initial state
+    clock.setState(nts::FALSE);
+
+    // Compute should return the current state after simulation
+    nts::Tristate result = clock.compute(1);
+    cr_assert_eq(result, nts::TRUE, "Compute should toggle and return TRUE");
+
+    // Next compute should toggle again
+    result = clock.compute(2);
+    cr_assert_eq(result, nts::FALSE, "Compute should toggle and return FALSE");
+}

--- a/tests/test_special_components.cpp
+++ b/tests/test_special_components.cpp
@@ -68,11 +68,25 @@ Test(Circuit, clock_behavior)
     circuit.addComponent("output", "output");
     circuit.linkComponents("clock", "output", 1, 1);
 
+    circuit.simulate(circuit.getTick() + 1);
+    cr_assert_eq(circuit.compute("output"), nts::UNDEFINED, "Output should be UNDEFINED");
+    circuit.setInputState(*dynamic_cast<nts::InputComponent*>(circuit.getComponent("clock").get()), nts::TRUE);
     cr_assert_eq(circuit.compute("output"), nts::UNDEFINED, "Output should be UNDEFINED");
     circuit.simulate(circuit.getTick() + 1);
     cr_assert_eq(circuit.compute("output"), nts::TRUE, "Output should be TRUE but is %d while clock is %d", circuit.compute("output"), circuit.compute("clock"));
     circuit.simulate(circuit.getTick() + 1);
     cr_assert_eq(circuit.compute("output"), nts::FALSE, "Output should be FALSE");
+}
+
+// clock with 2 pins
+Test(Circuit, clock_with_2_pins_behavior)
+{
+    nts::Circuit circuit;
+    circuit.addComponent("clock", "clock");
+    circuit.addComponent("output", "output");
+    circuit.linkComponents("clock", "output", 1, 1);
+
+    cr_assert_throw(circuit.linkComponents("clock", "output", 2, 1), std::invalid_argument, "Should throw for invalid pin");
 }
 
 // Test(Circuit, and_behavior)


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality of the `ClockComponent` and improve the overall codebase. The most important changes include adding a new test file for the `ClockComponent`, modifying the `Circuit` class to handle temporary components, and updating the `ClockComponent` to manage its state more effectively.

### Enhancements to `ClockComponent`:

* [`src/specialComponents/Clock.cpp`](diffhunk://#diff-4db45c13a7537349598a907674d56dcc2b4c813e46968c7c5634e043fadc8370L16-R48): Updated the `ClockComponent` to manage its state more effectively and handle the `manuallySet` flag.
* [`include/specialComponents/Clock.hpp`](diffhunk://#diff-c52670dba18aacba337beab926793e27c061409bf2e450d1c0dcb6183e321bc2R24): Added a `manuallySet` boolean flag to the `ClockComponent` class.

### Improvements to `Circuit` class:

* [`src/Circuit.cpp`](diffhunk://#diff-6e46614112db659b1ee900659cfccd579a3334f9c0c65172e7b4c29f582d4d6aL55-R64): Refactored the `displayInputs` method to prioritize displaying the state of `ClockComponent` before `InputComponent`.
* [`src/Circuit.cpp`](diffhunk://#diff-6e46614112db659b1ee900659cfccd579a3334f9c0c65172e7b4c29f582d4d6aR111-R120): Modified the `setInputState` method to use temporary components for state transitions and store them in `_tempComponents`.
* [`include/Circuit.hpp`](diffhunk://#diff-2c4bd5e424219f28ffa0659e18dcd08f037f463dcb8a4daf5202b14f29f52142R39): Added a `_tempComponents` vector to the `Circuit` class to store temporary components.

### Testing enhancements:

* [`tests/test_clock.cpp`](diffhunk://#diff-8cb7d30b39872daa4e9089f58702d1bfa769817e599e239cffcd25383fb0da33R1-R111): Added a new test file for the `ClockComponent` with multiple test cases to validate its behavior.
* [`tests/test_special_components.cpp`](diffhunk://#diff-1696ff7448bfd9e11af82fc09df2b2628afe13cc28cef6fe9c245022681a85d1R71-R91): Added new test cases to validate the behavior of the `Circuit` when simulating with the `ClockComponent`.

### Makefile update:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L35-R36): Added `tests/test_clock.cpp` to the list of test source files.… for component links