### PR TITLE
30 correction de laffichage

### DIFF
--- a/src/Circuit.cpp
+++ b/src/Circuit.cpp
@@ -55,6 +55,8 @@ void nts::Circuit::displayInputs() const
 {
     for (const auto &component : _components)
     {
+        if (component.first == "true" || component.first == "false" || component.first == "undefined")
+            continue;
         auto clock = dynamic_cast<nts::ClockComponent *>(component.second.get());
         if (clock != nullptr)
         {

--- a/tests/test_clock.cpp
+++ b/tests/test_clock.cpp
@@ -75,37 +75,37 @@ Test(ClockComponent, setLink_invalid) {
     cr_assert_throw(clock.setLink(2, mock, 1), std::invalid_argument, "Setting link to invalid pin should throw");
 }
 
-// Test(ClockComponent, simulate_toggle) {
-//     nts::ClockComponent clock("clock");
+Test(ClockComponent, simulate_toggle) {
+    nts::ClockComponent clock("clock");
 
-//     // Set initial state
-//     clock.setState(nts::TRUE);
-//     cr_assert_eq(clock.getState(), nts::TRUE, "Initial state should be TRUE");
+    // Set initial state
+    clock.setState(nts::TRUE);
+    cr_assert_eq(clock.getState(), nts::TRUE, "Initial state should be TRUE");
 
-//     // First simulate call should toggle state
-//     clock.simulate(1);
-//     cr_assert_eq(clock.getState(), nts::FALSE, "State should toggle to FALSE after simulate");
+    // First simulate call should toggle state
+    clock.simulate(1);
+    cr_assert_eq(clock.getState(), nts::FALSE, "State should toggle to FALSE after simulate");
 
-//     // Second simulate call should toggle state again
-//     clock.simulate(2);
-//     cr_assert_eq(clock.getState(), nts::TRUE, "State should toggle to TRUE after simulate");
+    // Second simulate call should toggle state again
+    clock.simulate(2);
+    cr_assert_eq(clock.getState(), nts::TRUE, "State should toggle to TRUE after simulate");
 
-//     // Simulate with same tick should not change state
-//     clock.simulate(2);
-//     cr_assert_eq(clock.getState(), nts::TRUE, "State should not change when tick is the same");
-// }
+    // Simulate with same tick should not change state
+    clock.simulate(2);
+    cr_assert_eq(clock.getState(), nts::TRUE, "State should not change when tick is the same");
+}
 
-// Test(ClockComponent, compute) {
-//     nts::ClockComponent clock("clock");
+Test(ClockComponent, compute) {
+    nts::ClockComponent clock("clock");
 
-//     // Set initial state
-//     clock.setState(nts::FALSE);
+    // Set initial state
+    clock.setState(nts::FALSE);
 
-//     // Compute should return the current state after simulation
-//     nts::Tristate result = clock.compute(1);
-//     cr_assert_eq(result, nts::TRUE, "Compute should toggle and return TRUE");
+    // Compute should return the current state after simulation
+    nts::Tristate result = clock.compute(1);
+    cr_assert_eq(result, nts::TRUE, "Compute should toggle and return TRUE");
 
-//     // Next compute should toggle again
-//     result = clock.compute(2);
-//     cr_assert_eq(result, nts::FALSE, "Compute should toggle and return FALSE");
-// }
+    // Next compute should toggle again
+    result = clock.compute(2);
+    cr_assert_eq(result, nts::FALSE, "Compute should toggle and return FALSE");
+}


### PR DESCRIPTION
This pull request includes changes to the `Circuit` class and the `ClockComponent` tests to improve functionality and test coverage. The most important changes include the addition of input filtering in the `Circuit::displayInputs` method and the re-enabling of previously commented-out tests for the `ClockComponent`.

Improvements to `Circuit` class:

* [`src/Circuit.cpp`](diffhunk://#diff-6e46614112db659b1ee900659cfccd579a3334f9c0c65172e7b4c29f582d4d6aR58-R59): Added input filtering in the `displayInputs` method to skip components with names "true", "false", or "undefined".

Enhancements to `ClockComponent` tests:

* [`tests/test_clock.cpp`](diffhunk://#diff-8cb7d30b39872daa4e9089f58702d1bfa769817e599e239cffcd25383fb0da33L78-R111): Re-enabled and fixed the `simulate_toggle` test for the `ClockComponent` to ensure it correctly toggles state on simulation.
* [`tests/test_clock.cpp`](diffhunk://#diff-8cb7d30b39872daa4e9089f58702d1bfa769817e599e239cffcd25383fb0da33L78-R111): Re-enabled and fixed the `compute` test for the `ClockComponent` to verify that the compute method correctly toggles and returns the state.